### PR TITLE
Copy Contexts Onto Objects

### DIFF
--- a/documentation/private_key.md
+++ b/documentation/private_key.md
@@ -8,6 +8,14 @@ Secp256k1::PrivateKey represents the private key part of a public-private key pa
 Initializers
 ------------
 
-#### new(private_key_data)
+#### new(context, private_key_data)
 
-Initializes the private key with the provided 32-byte `private_key_data`.
+Initializes the private key with the `in_context` and provided 32-byte binary
+string `private_key_data`.
+
+Class Methods
+-------------
+
+#### generate(context)
+
+Generates a new private key with `in_context`.


### PR DESCRIPTION
Currently, we copy around the `Context` struct rather than just cloning the
`secp256k1_context` itself. This probably causes segmentation faults when
object lifetimes are not closely aligned with those of the `Context` object
that created them.

This change modifies this so that contexts are cloned onto objects that require
them for instance methods. This makesso context lifetimes safer (e.g. objects
using a context cannot outlive it).