### PR TITLE
Add RecoverableSignature Type

### DIFF
--- a/ext/rbsecp256k1/extconf.rb
+++ b/ext/rbsecp256k1/extconf.rb
@@ -10,4 +10,7 @@ print("Looking for libsecp256k1")
 results = pkg_config('libsecp256k1')
 abort "missing libsecp256k1" unless results[1]
 
+# Check if we have the libsecp256k1 recoverable signature header.
+have_header('secp256k1_recovery.h')
+
 create_makefile('rbsecp256k1')

--- a/spec/unit/secp256k1_spec.rb
+++ b/spec/unit/secp256k1_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Secp256k1 do
+  describe '.have_recovery?' do
+    it 'is true when built with recovery module' do
+      expect(Secp256k1).to be_have_recovery
+    end
+  end
+end


### PR DESCRIPTION
Add the struct, data type, and basic class definition for the new
`RecoverableSignature` type. Optionally include the recoverable signature code
if the appropriate header is available.