### PR TITLE
Add Recoverable Signature Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ os:
   - "linux"
   - "osx"
 
+env:
+  - WITH_RECOVERY=1
+  - WITH_RECOVERY=0
+
 addons:
   apt:
     packages:

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,30 @@
 
 # Retrieve operating system name
 OS=$(shell uname -s)
+# Define the flags for libsecp256k1
+LIBSECP256K1_FLAGS=
 
 # On macOS we need to prefix to homebrew OpenSSL path before building
 ifeq ($(OS),Darwin)
 	COMPILE_PREFIX=PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
 endif
 
+ifeq ($(WITH_RECOVERY), 1)
+	LIBSECP256K1_FLAGS=--enable-module-recovery
+endif
+
 all: test
 
 deps:
-	cd vendor/secp256k1 && ./autogen.sh && ./configure --enable-module-recovery && make && sudo make install
+	cd vendor/secp256k1 && \
+	./autogen.sh && \
+	./configure $(LIBSECP256K1_FLAGS) && \
+	make && \
+	sudo make install
+
+uninstall-deps:
+	cd vendor/secp256k1 && \
+	sudo make uninstall
 
 setup:
 	bundle install

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -35,12 +35,23 @@ If `public_key_data` is a valid compressed or uncompressed public key, returns
 a new [PublicKey](public_key.md) object corresponding to. The `public_key_data`
 is expected to be a binary string.
 
+### recoverable_signature_from_compact(compact_signature, recovery_id)
+
+Attempts to load a [RecoverableSignature](recoverable_signature.md) from the given `compact_signature`
+and `recovery_id`. Raises a RuntimeError if the signature data or recovery ID are invalid.
+
 #### sign(private_key, data)
 
 Signs the SHA-256 hash of the given `data` using `private_key` and returns a
 new [Signature](signature.md). The `private_key` is expected to be a
 [PrivateKey](private_key.md) object and `data` can be either a binary string or
 text.
+
+### sign_recoverable(private_key, data)
+
+Signs the SHA-256 hash of the given `data` using `private_key` and returns a
+new [RecoverableSignature](recoverable_signature.md). The `private_key` is expected to be a [PrivateKey](private_key.md) and
+`data` can be either a binary string or text.
 
 #### signature_from_compact(compact_signature)
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -6,13 +6,14 @@ Find your topic in the index, or refer to one of the examples below.
 Classes and Modules
 -------------------
 
-Classes                          | Utilities
-:--------------------------------|:--------------------------------
-[Context](context.md)            | [Util](util.md)
-[KeyPair](key_pair.md)           |
-[PublicKey](public_key.md)       |
-[PrivateKey](private_key.md)     |
-[Signature](signature.md)        |
+Classes                                          | Utilities
+:------------------------------------------------|:--------------------------------
+[Context](context.md)                            | [Util](util.md)
+[KeyPair](key_pair.md)                           |
+[PublicKey](public_key.md)                       |
+[PrivateKey](private_key.md)                     |
+[Signature](signature.md)                        |
+[RecoverableSignature](recoverable_signature.md) |
 
 Glossary
 --------
@@ -30,6 +31,9 @@ compressed or uncompressed format.
 
 **[Signature](signature.md)** is an ECDSA signature of the SHA-256 message hash
 of a piece of data.
+
+**[RecoverableSignature](recoverable_signature.md)** is a recoverable ECDSA signature of the SHA-256 message
+hash of a piece of data.
 
 Examples
 --------

--- a/documentation/recoverable_signature.md
+++ b/documentation/recoverable_signature.md
@@ -1,0 +1,24 @@
+[Index](index.md)
+
+Secp256k1::RecoverableSignature
+===============================
+
+Secp256k1::RecoverableSignature represents a recoverable ECDSA signature
+signing the 32-byte SHA-256 hash of some data.
+
+Instance Methods
+----------------
+
+#### compact
+
+Returns an array whose first element is the 64-byte compact signature as a
+binary string and whose second element is the integer recovery ID.
+
+#### recover_public_key
+
+Recovers the public key corresponding to the recoverable signature. Returns a
+[PublicKey](public_key.md).
+
+#### to_signature
+
+Converts a recoverable signature to a non-recoverable [Signature](signature.md) object.

--- a/ext/rbsecp256k1/extconf.rb
+++ b/ext/rbsecp256k1/extconf.rb
@@ -1,12 +1,12 @@
 require 'mkmf'
 
 # OpenSSL flags
-print("Looking for OpenSSL")
+print("checking for OpenSSL\n")
 results = pkg_config('openssl')
 abort "missing openssl pkg-config information" unless results[1]
 
 # Require that libsecp256k1 be installed using `make install` or similar.
-print("Looking for libsecp256k1")
+print("checking for libsecp256k1\n")
 results = pkg_config('libsecp256k1')
 abort "missing libsecp256k1" unless results[1]
 

--- a/spec/unit/rbsecp256k1/recoverable_signature_spec.rb
+++ b/spec/unit/rbsecp256k1/recoverable_signature_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+if Secp256k1.have_recovery?
+  RSpec.describe Secp256k1::RecoverableSignature do
+    let(:context) { Secp256k1::Context.new }
+    let(:key_pair) { context.generate_key_pair }
+    let(:text_message) { 'more test stuff' }
+
+    describe '#compact' do
+      it 'returns the compact signature and recovery id' do
+        signature = context.sign_recoverable(key_pair.private_key, text_message)
+
+        signature, recovery_id = signature.compact
+        expect(signature).to be_a(String)
+        expect(signature.length).to be(64)
+        expect(recovery_id).to be_a(Integer)
+      end
+    end
+
+    describe '#to_signature' do
+      it 'returns the non-recoverable signature object' do
+        recoverable_signature = context.sign_recoverable(
+          key_pair.private_key, text_message
+        )
+        compact, = recoverable_signature.compact
+
+        signature = recoverable_signature.to_signature
+        expect(signature).to be_a(Secp256k1::Signature)
+        expect(signature.compact.bytes).to eq(compact.bytes)
+      end
+    end
+
+    describe '#recover_public_key' do
+      it 'recovers the public key from signature' do
+        recoverable_signature = context.sign_recoverable(
+          key_pair.private_key, text_message
+        )
+
+        recovered_public_key = recoverable_signature.recover_public_key(
+          text_message
+        )
+
+        expect(recovered_public_key).to be_a(Secp256k1::PublicKey)
+        expect(recovered_public_key.compressed.bytes)
+          .to eq(key_pair.public_key.compressed.bytes)
+      end
+
+      it 'bad data to result in wrong public key' do
+        recoverable_signature = context.sign_recoverable(
+          key_pair.private_key, text_message
+        )
+
+        public_key = recoverable_signature.recover_public_key(
+          text_message + 'bad data'
+        )
+
+        expect(public_key).to be_a(Secp256k1::PublicKey)
+        expect(public_key.compressed.bytes)
+          .not_to eq(key_pair.public_key.compressed.bytes)
+      end
+    end
+  end
+end

--- a/spec/unit/secp256k1_spec.rb
+++ b/spec/unit/secp256k1_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe Secp256k1 do
+  # Pull down the WITH_RECOVERY environment variable. This should be '1' in
+  # environments where tests are being run with the recovery module installed.
+  let(:with_recovery) { ENV.fetch('WITH_RECOVERY', '0') == '1' }
+
   describe '.have_recovery?' do
-    it 'is true when built with recovery module' do
-      expect(Secp256k1).to be_have_recovery
+    it 'has the expected recovery module' do
+      expect(Secp256k1.have_recovery?).to eq(with_recovery)
     end
   end
 end


### PR DESCRIPTION
Closes #5

Add support for recoverable signatures - signatures from which a public key
can be recovered. Add unit-tests corresponding to this and provide the
following new methods and classes:

  * `Context#sign_recoverable`
  * `Context#recoverable_signature_from_compact`
  * `RecoverableSignature`
  * `RecoverableSignature#compact`
  * `RecoverableSignature#recover_public_key`
  * `RecoverableSignature#to_signature`