### PR TITLE
Replace PublicKey and PrivateKey initializers

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -29,13 +29,18 @@ Returns a new [KeyPair](key_pair.md) from the given `private_key_data`. The
 `private_key_data` is expected to be a binary string. Raises a `RuntimeError`
 if the private key is invalid or key derivation fails.
 
+#### private_key_from_data(private_key_data)
+
+Creates a new [PrivateKey](private_key.md) from `private_key_data`. Raises an `ArgumentError`
+if private key is invalid.
+
 #### public_key_from_data(public_key_data)
 
 If `public_key_data` is a valid compressed or uncompressed public key, returns
 a new [PublicKey](public_key.md) object corresponding to. The `public_key_data`
 is expected to be a binary string.
 
-### recoverable_signature_from_compact(compact_signature, recovery_id)
+#### recoverable_signature_from_compact(compact_signature, recovery_id)
 
 Attempts to load a [RecoverableSignature](recoverable_signature.md) from the given `compact_signature`
 and `recovery_id`. Raises a RuntimeError if the signature data or recovery ID are invalid.

--- a/documentation/private_key.md
+++ b/documentation/private_key.md
@@ -5,17 +5,9 @@ Secp256k1::PrivateKey
 
 Secp256k1::PrivateKey represents the private key part of a public-private key pair.
 
-Initializers
-------------
+Instance Methods
+----------------
 
-#### new(context, private_key_data)
+#### data
 
-Initializes the private key with the `in_context` and provided 32-byte binary
-string `private_key_data`.
-
-Class Methods
--------------
-
-#### generate(context)
-
-Generates a new private key with `in_context`.
+Returns the binary private key data as a `String`.

--- a/documentation/public_key.md
+++ b/documentation/public_key.md
@@ -7,14 +7,6 @@ Secp256k1::PublicKey represents the public key part of a public-private key pair
 
 See: [KeyPair](key_pair.md)
 
-Initializers
-------------
-
-#### new(context, private_key)
-
-Creates a new public key derived from `private_key` (type: [PrivateKey](private_key.md)) using
-`context` (type: [Context](context.md)).
-
 Instance Methods
 ----------------
 

--- a/spec/unit/rbsecp256k1/private_key_spec.rb
+++ b/spec/unit/rbsecp256k1/private_key_spec.rb
@@ -4,18 +4,9 @@ RSpec.describe Secp256k1::PrivateKey do
   let(:context) { Secp256k1::Context.new }
 
   it 'does not allow you to write data' do
-    private_key = Secp256k1::PrivateKey.generate(context)
+    key_pair = context.generate_key_pair
     expect do
-      private_key.data = 'test'
+      key_pair.private_key.data = 'test'
     end.to raise_error(NoMethodError)
-  end
-
-  describe '.generate' do
-    it 'generates a new private key' do
-      private_key = Secp256k1::PrivateKey.generate(context)
-      expect(private_key).to be_a(Secp256k1::PrivateKey)
-      expect(private_key.data).to be_a(String)
-      expect(private_key.data.length).to eq 32
-    end
   end
 end

--- a/spec/unit/rbsecp256k1/public_key_spec.rb
+++ b/spec/unit/rbsecp256k1/public_key_spec.rb
@@ -4,20 +4,6 @@ RSpec.describe Secp256k1::PublicKey do
   let(:context) { Secp256k1::Context.new }
   let(:key_pair) { context.generate_key_pair }
 
-  describe '#initialize' do
-    it 'initializes a public key from private key data' do
-      public_key = Secp256k1::PublicKey.new(context, key_pair.private_key)
-
-      expect(public_key).to be_a(Secp256k1::PublicKey)
-    end
-
-    it 'raises an error if the private key data is invalid' do
-      expect do
-        Secp256k1::PublicKey.new(context, 'test')
-      end.to raise_error(TypeError)
-    end
-  end
-
   describe '#uncompressed' do
     it 'returns the uncompressed form of the public key' do
       uncompressed = key_pair.public_key.uncompressed


### PR DESCRIPTION
Remove `PublicKey#initialize` and `PrivateKey#initialize`. Replace the previous
`PrivateKey#initialize` method with `Context#private_key_from_data`. We did not
add a substitute for `PublicKey#initialize` as it seems largely unnecessary at
this point.