### PR TITLE
Add ECDH module detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,14 @@ ifeq ($(OS),Darwin)
 	COMPILE_PREFIX=PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
 endif
 
+# Enable recovery module
 ifeq ($(WITH_RECOVERY), 1)
-	LIBSECP256K1_FLAGS=--enable-module-recovery
+	LIBSECP256K1_FLAGS+=--enable-module-recovery
+endif
+
+# Enable EC Diffie-Hellman module
+ifeq ($(WITH_ECDH), 1)
+	LIBSECP256K1_FLAGS+= --enable-ecdh
 endif
 
 all: test

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -6,14 +6,14 @@ Find your topic in the index, or refer to one of the examples below.
 Classes and Modules
 -------------------
 
-Classes                                          | Utilities
-:------------------------------------------------|:--------------------------------
-[Context](context.md)                            | [Util](util.md)
-[KeyPair](key_pair.md)                           |
-[PublicKey](public_key.md)                       |
-[PrivateKey](private_key.md)                     |
-[Signature](signature.md)                        |
-[RecoverableSignature](recoverable_signature.md) |
+| Module                     | Classes                                          | Utilities
+|----------------------------|:-------------------------------------------------|:--------------------------------
+| [Secp256k1](secp256k1.md)  | [Context](context.md)                            | [Util](util.md)
+|                            | [KeyPair](key_pair.md)                           |
+|                            | [PublicKey](public_key.md)                       |
+|                            | [PrivateKey](private_key.md)                     |
+|                            | [Signature](signature.md)                        |
+|                            | [RecoverableSignature](recoverable_signature.md) |
 
 Glossary
 --------

--- a/documentation/secp256k1.md
+++ b/documentation/secp256k1.md
@@ -1,0 +1,19 @@
+[Index](index.md)
+
+Secp256k1
+=========
+
+Secp256k1 is the top-level module for this library.
+
+Class Methods
+-------------
+
+#### have_recovery?
+
+Returns `true` if the recovery module was built with libsecp256k1, `false`
+otherwise.
+
+#### have_ecdh?
+
+Returns `true` if the EC Diffie-Hellman module was built with libsecp256k1,
+`false` otherwise.

--- a/ext/rbsecp256k1/extconf.rb
+++ b/ext/rbsecp256k1/extconf.rb
@@ -13,4 +13,7 @@ abort "missing libsecp256k1" unless results[1]
 # Check if we have the libsecp256k1 recoverable signature header.
 have_header('secp256k1_recovery.h')
 
+# Check if we have EC Diffie-Hellman functionality
+have_header('secp256k1_ecdh.h')
+
 create_makefile('rbsecp256k1')

--- a/ext/rbsecp256k1/rbsecp256k1.c
+++ b/ext/rbsecp256k1/rbsecp256k1.c
@@ -20,6 +20,11 @@
 #include <secp256k1_recovery.h>
 #endif // HAVE_SECP256K1_RECOVERY_H
 
+// Include EC Diffie-Hellman functionality
+#ifdef HAVE_SECP256K1_ECDH_H
+#include <secp256k1_ecdh.h>
+#endif // HAVE_SECP256K1_ECDH_H
+
 // High-level design:
 //
 // The Ruby wrapper is divided into the following hierarchical organization:
@@ -1350,9 +1355,10 @@ Context_recoverable_signature_from_compact(
 //
 
 /**
- * Indicates whether or not the libsecp256k1 recovery module was built.
+ * Indicates whether or not the libsecp256k1 recovery module is installed.
  *
- * @return [Boolean] True if libsecp256k1 was built with the recovery module.
+ * @return [Boolean] true if libsecp256k1 was built with the recovery module,
+ *   false otherwise.
  */
 static VALUE
 Secp256k1_have_recovery(VALUE module)
@@ -1362,6 +1368,22 @@ Secp256k1_have_recovery(VALUE module)
 #else // HAVE_SECP256K1_RECOVERY_H
   return Qfalse;
 #endif // HAVE_SECP256K1_RECOVERY_H
+}
+
+/**
+ * Indicates whether or not libsecp256k1 EC Diffie-Hellman module is installed.
+ *
+ * @return [Boolean] true if libsecp256k1 was build with the ECDH module, false
+ *   otherwise.
+ */
+static VALUE
+Secp256k1_have_ecdh(VALUE module)
+{
+#ifdef HAVE_SECP256K1_ECDH_H
+  return Qtrue;
+#else // HAVE_SECP256K1_ECDH_H
+  return Qfalse;
+#endif // HAVE_SECP256K1_ECDH_H
 }
 
 //
@@ -1383,6 +1405,12 @@ void Init_rbsecp256k1()
     Secp256k1_module,
     "have_recovery?",
     Secp256k1_have_recovery,
+    0
+  );
+  rb_define_singleton_method(
+    Secp256k1_module,
+    "have_ecdh?",
+    Secp256k1_have_ecdh,
     0
   );
 

--- a/spec/unit/secp256k1_spec.rb
+++ b/spec/unit/secp256k1_spec.rb
@@ -10,4 +10,10 @@ RSpec.describe Secp256k1 do
       expect(Secp256k1.have_recovery?).to eq(with_recovery)
     end
   end
+
+  describe '.have_ecdh?' do
+    it 'has the expected ecdh module' do
+      expect(Secp256k1.have_ecdh?).to be false
+    end
+  end
 end


### PR DESCRIPTION
Add the ability to detect the `secp256k1_ecdh.h` module installation and a new
predicate `Secp256k1.have_ecdh?` that indicates whether or not this module is
installed.