### PR TITLE
Add Support For Experimental ECDH Module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ os:
 env:
   - WITH_RECOVERY=1
   - WITH_RECOVERY=0
+  - WITH_ECDH=1
+  - WITH_ECDH=0
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 # Enable EC Diffie-Hellman module
 ifeq ($(WITH_ECDH), 1)
-	LIBSECP256K1_FLAGS+= --enable-ecdh
+	LIBSECP256K1_FLAGS+= --enable-module-ecdh --enable-experimental
 endif
 
 all: test

--- a/README.md
+++ b/README.md
@@ -19,16 +19,7 @@ and macOS sections below.
 To build libsecp256k1 from source you can do the following:
 
 ```
-make deps
-```
-
-Or if you want to build it yourself from the repository, you should do the following:
-
-```
-./autogen.sh
-./configure --enable-module-recovery
-make
-sudo make install
+make deps WITH_RECOVERY=1 WITH_ECDH=1
 ```
 
 ### Linux
@@ -109,6 +100,14 @@ install it you can run:
 make deps
 ```
 
+### Uninstalling libsecp256k1
+
+libsecp256k1 can also be uninstall:
+
+```
+make uninstall-deps
+```
+
 ### Setup
 
 Development is largely facilitated by a makefile. After download you should run
@@ -152,6 +151,22 @@ You can similarly uninstall the local gem by running the following:
 
 ```
 make uninstall
+```
+
+### Cleaning Up
+
+To clean up and do a fresh build:
+
+```
+make clean
+```
+
+### Running YARD Documentation Server
+
+To run the [YARD](https://yardoc.org/) documentation server:
+
+```
+make docserver
 ```
 
 ### Linux

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -18,6 +18,14 @@ initialization.
 Instance Methods
 ----------------
 
+#### ecdh(point, scalar)
+
+**Requires:** libsecp256k1 was built with the experimental ECDH module.
+
+Takes a `point` ([PublicKey]) and a `scalar` ([PrivateKey]) and returns a new
+[SharedSecret] containing the 32-byte shared secret. Raises a `RuntimeError` if
+the `scalar` is invalid (zero or causes an overflow).
+
 #### generate_key_pair
 
 Generates and returns a new [KeyPair](key_pair.md) using a cryptographically
@@ -42,6 +50,8 @@ is expected to be a binary string.
 
 #### recoverable_signature_from_compact(compact_signature, recovery_id)
 
+**Requires:** libsecp256k1 was build with recovery module.
+
 Attempts to load a [RecoverableSignature](recoverable_signature.md) from the given `compact_signature`
 and `recovery_id`. Raises a RuntimeError if the signature data or recovery ID are invalid.
 
@@ -52,6 +62,8 @@ Signs the SHA-256 hash given by `hash32` using `private_key` and returns a new
 object and `data` can be either a binary string or text.
 
 ### sign_recoverable(private_key, hash32)
+
+**Requires:** libsecp256k1 was build with recovery module.
 
 Signs the data represented by the SHA-256 hash `hash32` using `private_key` and returns a
 new [RecoverableSignature](recoverable_signature.md). The `private_key` is expected to be a [PrivateKey](private_key.md) and

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -12,6 +12,7 @@ Classes and Modules
 |                            | [KeyPair](key_pair.md)                           |
 |                            | [PublicKey](public_key.md)                       |
 |                            | [PrivateKey](private_key.md)                     |
+|                            | [SharedSecret](shared_secret.md)                 |
 |                            | [Signature](signature.md)                        |
 |                            | [RecoverableSignature](recoverable_signature.md) |
 
@@ -28,6 +29,9 @@ efficient.
 compressed or uncompressed format.
 
 **[PrivateKey](private_key.md)** is a 64-byte Secp256k1 private key.
+
+**[SharedSecret](shared_secret.md)** A 32-byte shared secret computed from a
+public key (point) and private key (scalar).
 
 **[Signature](signature.md)** is an ECDSA signature of the SHA-256 message hash
 of a piece of data.

--- a/documentation/recoverable_signature.md
+++ b/documentation/recoverable_signature.md
@@ -3,6 +3,8 @@
 Secp256k1::RecoverableSignature
 ===============================
 
+**Requires:** libsecp256k1 was build with recovery module.
+
 Secp256k1::RecoverableSignature represents a recoverable ECDSA signature
 signing the 32-byte SHA-256 hash of some data.
 

--- a/documentation/shared_secret.md
+++ b/documentation/shared_secret.md
@@ -1,0 +1,16 @@
+[Index](index.md)
+
+Secp256k1::SharedSecret
+=======================
+
+**Requires:** libsecp256k1 was build with ECDH module.
+
+Secp256k1::SharedSecret represents a 32-byte shared secret computed from a
+public key (point) and private key (scalar).
+
+Instance Methods
+----------------
+
+#### data
+
+Binary string containing the 32-byte shared secret.

--- a/spec/unit/rbsecp256k1/context_spec.rb
+++ b/spec/unit/rbsecp256k1/context_spec.rb
@@ -241,4 +241,16 @@ RSpec.describe Secp256k1::Context do
       end
     end
   end
+
+  if Secp256k1.have_ecdh?
+    describe '#ecdh' do
+      it 'produces a shared secret from keys' do
+        shared_secret = subject.ecdh(key_pair.public_key, key_pair.private_key)
+
+        expect(shared_secret).to be_a(Secp256k1::SharedSecret)
+        expect(shared_secret.data).to be_a(String)
+        expect(shared_secret.data.length).to eq(32)
+      end
+    end
+  end
 end

--- a/spec/unit/secp256k1_spec.rb
+++ b/spec/unit/secp256k1_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Secp256k1 do
   # environments where tests are being run with the recovery module installed.
   let(:with_recovery) { ENV.fetch('WITH_RECOVERY', '0') == '1' }
 
+  # Pull down the WITH_ECDH environment variable. This should be '1' in
+  # environments where tests are being run with the ECDH module installed.
+  let(:with_ecdh) { ENV.fetch('WITH_ECDH', '0') == '1' }
+
   describe '.have_recovery?' do
     it 'has the expected recovery module' do
       expect(Secp256k1.have_recovery?).to eq(with_recovery)
@@ -13,7 +17,7 @@ RSpec.describe Secp256k1 do
 
   describe '.have_ecdh?' do
     it 'has the expected ecdh module' do
-      expect(Secp256k1.have_ecdh?).to be false
+      expect(Secp256k1.have_ecdh?).to eq(with_ecdh)
     end
   end
 end


### PR DESCRIPTION
Closes #8

Add support for the experimental EC Diffie-Hellman module (for those brave
enough to use it). This adds two new things:
  * `Context#ecdh`
  * `SharedSecret`