### PR TITLE
Add Fuzzing Tests

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -22,8 +22,8 @@ Instance Methods
 
 **Requires:** libsecp256k1 was built with the experimental ECDH module.
 
-Takes a `point` ([PublicKey]) and a `scalar` ([PrivateKey]) and returns a new
-[SharedSecret] containing the 32-byte shared secret. Raises a `RuntimeError` if
+Takes a `point` ([PublicKey](public_key.md)) and a `scalar` ([PrivateKey](private_key.md)) and returns a new
+[SharedSecret](shared_secret.md) containing the 32-byte shared secret. Raises a `RuntimeError` if
 the `scalar` is invalid (zero or causes an overflow).
 
 #### generate_key_pair
@@ -61,7 +61,7 @@ Signs the SHA-256 hash given by `hash32` using `private_key` and returns a new
 [Signature](signature.md). The `private_key` is expected to be a [PrivateKey](private_key.md)
 object and `data` can be either a binary string or text.
 
-### sign_recoverable(private_key, hash32)
+#### sign_recoverable(private_key, hash32)
 
 **Requires:** libsecp256k1 was build with recovery module.
 
@@ -83,7 +83,7 @@ Raises a `RuntimeError` if the signature data is invalid.
 
 #### verify(signature, public_key, hash32)
 
-Verifies the given `signature` (type: [Signature](signature.md)) was signed by
-the private key corresponding to `public_key` (type: [PublicKey](public_key.md)) and signed `hash32`. Returns `true`
+Verifies the given `signature` ([Signature](signature.md)) was signed by
+the private key corresponding to `public_key` ([PublicKey](public_key.md)) and signed `hash32`. Returns `true`
 if `signature` is valid or `false` otherwise. Note that `data` can be either a
 text or binary string.

--- a/ext/rbsecp256k1/rbsecp256k1.c
+++ b/ext/rbsecp256k1/rbsecp256k1.c
@@ -277,7 +277,7 @@ typedef enum ResultT_dummy {
  *   RESULT_FAILURE otherwise.
  */
 static ResultT
-GenerateRandomBytes(unsigned char *out_bytes, size_t in_size)
+GenerateRandomBytes(unsigned char *out_bytes, int in_size)
 {
   // OpenSSL RNG has not been seeded with enough data and is therefore
   // not usable.
@@ -1110,7 +1110,7 @@ Context_public_key_from_data(VALUE self, VALUE in_public_key_data)
   return PublicKey_create_from_data(
     context,
     public_key_data,
-    RSTRING_LEN(in_public_key_data)
+    (int)RSTRING_LEN(in_public_key_data)
   );
 }
 
@@ -1228,6 +1228,13 @@ Context_signature_from_compact(VALUE self, VALUE in_compact_signature)
   Signature *signature;
   VALUE signature_result;
   unsigned char *signature_data;
+
+  Check_Type(in_compact_signature, T_STRING);
+
+  if (RSTRING_LEN(in_compact_signature) != 64)
+  {
+    rb_raise(rb_eArgError, "compact signature must be 64 bytes");
+  }
 
   TypedData_Get_Struct(self, Context, &Context_DataType, context);
   signature_data = (unsigned char*)StringValuePtr(in_compact_signature);

--- a/spec/fuzzing/serialization_fuzzing_spec.rb
+++ b/spec/fuzzing/serialization_fuzzing_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+# Fuzzing tests check deserialization methods against randomly generated data.
+# These tests reuse the random seed provided to RSpec so that failures are
+# reproducible.
+
+RSpec.describe 'Fuzzing deserialization methods' do
+  let(:context) { Secp256k1::Context.new }
+  let(:seed) { RSpec.configuration.seed }
+  let(:random) { Random.new(seed) }
+
+  before do
+    srand(seed)
+  end
+
+  def random_binary_data(min_size, max_size)
+    num_bytes = rand(min_size..max_size)
+    random.bytes(num_bytes)
+  end
+
+  # rubocop:disable Lint/HandleExceptions
+  def fuzz_random_binary_data(iterations, min_bytes:, max_bytes:, &_block)
+    iterations.times do
+      yield random_binary_data(min_bytes, max_bytes)
+    end
+  rescue StandardError
+    # Ignore errors, we're looking for crashes
+  end
+  # rubocop:enable Lint/HandleExceptions
+
+  it 'does not crash Context#key_pair_from_private_key' do
+    fuzz_random_binary_data(10_000, min_bytes: 0, max_bytes: 100) do |fuzzing_data|
+      context.key_pair_from_private_key(fuzzing_data)
+    end
+  end
+
+  it 'does not crash Context#private_key_from_data' do
+    fuzz_random_binary_data(10_000, min_bytes: 0, max_bytes: 100) do |fuzzing_data|
+      context.private_key_from_data(fuzzing_data)
+    end
+  end
+
+  it 'does not crash Context#recoverable_signature_from_compact' do
+    if Secp256k1.have_recovery?
+      fuzz_random_binary_data(10_000, min_bytes: 0, max_bytes: 100) do |fuzzing_data|
+        context.recoverable_signature_from_compact(fuzzing_data, rand(1..3))
+      end
+    end
+  end
+
+  it 'does not crash Context#signature_from_der_encoded' do
+    fuzz_random_binary_data(10_000, min_bytes: 0, max_bytes: 100) do |fuzzing_data|
+      context.signature_from_der_encoded(fuzzing_data)
+    end
+  end
+
+  it 'does not crash Context#signature_from_compact' do
+    fuzz_random_binary_data(10_000, min_bytes: 0, max_bytes: 100) do |fuzzing_data|
+      context.signature_from_compact(fuzzing_data)
+    end
+  end
+end


### PR DESCRIPTION
Add some fuzzing tests to look for crashes in the deserialization methods. Fuzz
tests are seeding using the same random seed RSpec is using. This makes them
reproducible.