### PR TITLE
Add More Validations

### DIFF
--- a/ext/rbsecp256k1/rbsecp256k1.c
+++ b/ext/rbsecp256k1/rbsecp256k1.c
@@ -1156,6 +1156,8 @@ Context_key_pair_from_private_key(VALUE self, VALUE in_private_key_data)
   VALUE private_key;
   unsigned char *private_key_data;
 
+  Check_Type(in_private_key_data, T_STRING);
+
   if (RSTRING_LEN(in_private_key_data) != 32)
   {
     rb_raise(rb_eArgError, "private key data must be 32 bytes in length");
@@ -1400,10 +1402,11 @@ Context_sign_recoverable(VALUE self, VALUE in_private_key, VALUE in_hash32)
  *
  * @param in_compact_sig [String] binary string containing compact signature
  *   data.
- * @param in_recovery_id [Integer] recovery ID.
+ * @param in_recovery_id [Integer] recovery ID (range [0, 3])
  * @return [Secp256k1::RecoverableSignature] signature parsed from data.
  * @raise [RuntimeError] if signature data or recovery ID is invalid.
- * @raise [ArgumentError] if compact signature is not 64 bytes.
+ * @raise [ArgumentError] if compact signature is not 64 bytes or recovery ID
+ *   is not in range [0, 3].
  */
 static VALUE
 Context_recoverable_signature_from_compact(
@@ -1425,6 +1428,11 @@ Context_recoverable_signature_from_compact(
   if (RSTRING_LEN(in_compact_sig) != 64)
   {
     rb_raise(rb_eArgError, "compact signature is not 64 bytes");
+  }
+
+  if (recovery_id < 0 || recovery_id > 3)
+  {
+    rb_raise(rb_eArgError, "invalid recovery ID, must be in range [0, 3]");
   }
 
   result = RecoverableSignature_alloc(Secp256k1_RecoverableSignature_class);

--- a/spec/unit/rbsecp256k1/context_spec.rb
+++ b/spec/unit/rbsecp256k1/context_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe Secp256k1::Context do
         subject.key_pair_from_private_key('abcdefghijklmnopqrstuvwxyzabcd')
       end.to raise_error(ArgumentError, 'private key data must be 32 bytes in length')
     end
+
+    it 'raises an error if private key data is not string' do
+      expect do
+        subject.key_pair_from_private_key(1234)
+      end.to raise_error(TypeError)
+    end
   end
 
   describe '#private_key_from_data' do
@@ -62,6 +68,12 @@ RSpec.describe Secp256k1::Context do
       expect do
         subject.private_key_from_data('test')
       end.to raise_error(ArgumentError, 'private key data must be 32 bytes in length')
+    end
+
+    it 'raises an error if private key data is not string' do
+      expect do
+        subject.private_key_from_data(1234)
+      end.to raise_error(TypeError)
     end
   end
 
@@ -85,6 +97,12 @@ RSpec.describe Secp256k1::Context do
         subject.public_key_from_data(Random.new.bytes(64))
       end.to raise_error(RuntimeError, 'invalid public key data')
     end
+
+    it 'raises an error if public key data is not string' do
+      expect do
+        subject.public_key_from_data(1234)
+      end.to raise_error(TypeError)
+    end
   end
 
   describe '#private_key_from_data' do
@@ -94,6 +112,12 @@ RSpec.describe Secp256k1::Context do
 
       expect(private_key).to be_a(Secp256k1::PrivateKey)
       expect(private_key.data.bytes).to eq(data.bytes)
+    end
+
+    it 'raises an error if data is not string' do
+      expect do
+        subject.private_key_from_data(1234)
+      end.to raise_error(TypeError)
     end
   end
 
@@ -151,7 +175,7 @@ RSpec.describe Secp256k1::Context do
       expect(result).to eq(signature)
     end
 
-    it 'raises an error if invalid signature data is given' do
+    it 'raises an error if signature data is not string' do
       expect do
         subject.signature_from_compact(123)
       end.to raise_error(TypeError)
@@ -238,6 +262,30 @@ RSpec.describe Secp256k1::Context do
         expect do
           subject.recoverable_signature_from_compact('test', 1)
         end.to raise_error(ArgumentError, 'compact signature is not 64 bytes')
+      end
+
+      it 'raises an error if compact signature data is not string' do
+        expect do
+          subject.recoverable_signature_from_compact(1234, 1)
+        end.to raise_error(TypeError)
+      end
+
+      it 'raises an error if recovery id is less < 0' do
+        signature = subject.sign_recoverable(key_pair.private_key, sha256('test'))
+        compact, = signature.compact
+
+        expect do
+          subject.recoverable_signature_from_compact(compact, -1)
+        end.to raise_error(ArgumentError, /invalid recovery ID/)
+      end
+
+      it 'raises an error if recovery id is > 3' do
+        signature = subject.sign_recoverable(key_pair.private_key, sha256('test'))
+        compact, = signature.compact
+
+        expect do
+          subject.recoverable_signature_from_compact(compact, 4)
+        end.to raise_error(ArgumentError, /invalid recovery ID/)
       end
     end
   end


### PR DESCRIPTION
* Add mising `String` type check in `key_pair_from_private_key`.
* Add `recovery_id` range check in `recoverable_signature_from_compact`.
* Add tests to ensure that inputs of the incorrec type are rejected.
* Add tests to ensure invalid recovery IDs are rejected.