### PR TITLE
Default To Downloading libsecp256k1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Metrics/LineLength:
   Max: 250
 
+Metrics/MethodLength:
+  Max: 50
+
 Metrics/BlockLength:
   Max: 1000
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: ruby
 
 rvm:
@@ -8,10 +9,11 @@ os:
   - "linux"
   - "osx"
 
+# WITH_RECOVERY and WITH_ECDH are 1 by default. Test all variants where they
+# are 0.
 env:
-  - WITH_RECOVERY=1
+  - WITH_RECOVERY=0 WITH_ECDH=0
   - WITH_RECOVERY=0
-  - WITH_ECDH=1
   - WITH_ECDH=0
 
 addons:
@@ -27,12 +29,12 @@ addons:
       - python-dev
 
 before_install:
+  - gem update --system
+  - gem install bundler
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libtool pkg-config gmp libffi ; fi
 
 script:
-  - make deps
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ldconfig ; fi
   - make setup
   - make build
   - make lint

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: test
 deps:
 	cd vendor/secp256k1 && \
 	./autogen.sh && \
-	./configure $(LIBSECP256K1_FLAGS) && \
+	./configure --disable-benchmark --disable-exhaustive-tests --enable-shared=no --disable-tests --disable-debug $(LIBSECP256K1_FLAGS) && \
 	make && \
 	sudo make install
 

--- a/ext/rbsecp256k1/extconf.rb
+++ b/ext/rbsecp256k1/extconf.rb
@@ -1,14 +1,103 @@
+require 'mini_portile2'
 require 'mkmf'
+require 'zip'
+
+# Recipe for downloading and building libsecp256k1 as part of installation
+class Secp256k1Recipe < MiniPortile
+  # Hard-coded URL for downloading zipfile
+  LIBSECP256K1_ZIP_URL = 'https://github.com/bitcoin-core/secp256k1/archive/master.zip'.freeze
+
+  WITH_RECOVERY = ENV.fetch('WITH_RECOVERY', '1') == '1'
+  WITH_ECDH = ENV.fetch('WITH_ECDH', '1') == '1'
+
+  def initialize
+    super('libsecp256k1', '0.0.0')
+    @tarball = File.join(Dir.pwd, "/ports/archives/libsecp256k1.zip")
+    @files = ["file://#{@tarball}"]
+    self.configure_options += [
+      "--disable-benchmark",
+      "--disable-exhaustive-tests",
+      "--disable-tests",
+      "--disable-debug",
+      "--enable-experimental",
+      "--with-pic=yes"
+    ]
+
+    configure_options << "--enable-module-recovery" if WITH_RECOVERY
+    configure_options << "--enable-module-ecdh" if WITH_ECDH
+  end
+
+  def configure
+    # Need to run autogen.sh before configure since it creates it
+    if RUBY_PLATFORM =~ /mingw|mswin/
+      # Windows doesn't recognize the shebang.
+      execute('autogen', %w[sh ./autogen.sh])
+    else
+      execute('autogen', %w[./autogen.sh])
+    end
+
+    super
+  end
+
+  def download
+    download_file_http(LIBSECP256K1_ZIP_URL, @tarball)
+  end
+
+  def downloaded?
+    File.exist?(@tarball)
+  end
+
+  def extract_zip_file(file, destination)
+    FileUtils.mkdir_p(destination)
+
+    Zip::File.open(file) do |zip_file|
+      zip_file.each do |f|
+        fpath = File.join(destination, f.name)
+        zip_file.extract(f, fpath) unless File.exist?(fpath)
+      end
+    end
+  end
+
+  def extract
+    files_hashs.each do |file|
+      extract_zip_file(file[:local_path], tmp_path)
+    end
+  end
+end
 
 # OpenSSL flags
 print("checking for OpenSSL\n")
 results = pkg_config('openssl')
-abort "missing openssl pkg-config information" unless results[1]
+abort "missing openssl pkg-config information" unless results && results[1]
 
-# Require that libsecp256k1 be installed using `make install` or similar.
-print("checking for libsecp256k1\n")
-results = pkg_config('libsecp256k1')
-abort "missing libsecp256k1" unless results[1]
+if with_config('system-library')
+  # Require that libsecp256k1 be installed using `make install` or similar.
+  print("checking for libsecp256k1\n")
+  results = pkg_config('libsecp256k1')
+  abort "missing libsecp256k1" unless results && results[1]
+else
+  # Build the libsecp256k1 dependency
+  recipe = Secp256k1Recipe.new
+  recipe.cook
+  recipe.activate
+
+  # Need to add paths to includes and libraries for library for build
+  append_cflags(
+    [
+      "-I#{recipe.path}/include",
+      "-fPIC",
+      "-Wno-undef",
+      "-Wall"
+    ]
+  )
+  # rubocop:disable Style/GlobalVars
+  $LIBPATH = ["#{recipe.path}/lib"] | $LIBPATH
+  # rubocop:enable Style/GlobalVars
+
+  # Also need to make sure we add the library as part of the build
+  have_library("secp256k1")
+  have_library("gmp")
+end
 
 # Check if we have the libsecp256k1 recoverable signature header.
 have_header('secp256k1_recovery.h')

--- a/rbsecp256k1.gemspec
+++ b/rbsecp256k1.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |s|
 
   s.extensions = ['ext/rbsecp256k1/extconf.rb']
 
+  # Dependencies required to build and run this gem
+  s.add_dependency 'mini_portile2', '~> 2.4'
+  s.add_dependency 'rubyzip', '~> 1.2'
+
   # Development dependencies
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rake-compiler', '~> 1.0'

--- a/spec/unit/secp256k1_spec.rb
+++ b/spec/unit/secp256k1_spec.rb
@@ -1,13 +1,15 @@
 require 'spec_helper'
 
 RSpec.describe Secp256k1 do
-  # Pull down the WITH_RECOVERY environment variable. This should be '1' in
-  # environments where tests are being run with the recovery module installed.
-  let(:with_recovery) { ENV.fetch('WITH_RECOVERY', '0') == '1' }
+  # Pull down the WITH_RECOVERY environment variable. This should be '0' in
+  # environments where tests are being run with the recovery module
+  # uninstalled. The recovery module will be installed by default.
+  let(:with_recovery) { ENV.fetch('WITH_RECOVERY', '1') == '1' }
 
-  # Pull down the WITH_ECDH environment variable. This should be '1' in
-  # environments where tests are being run with the ECDH module installed.
-  let(:with_ecdh) { ENV.fetch('WITH_ECDH', '0') == '1' }
+  # Pull down the WITH_ECDH environment variable. This should be '0' in
+  # environments where tests are being run with the ECDH module not installed.
+  # The ECDH module will be installed by default.
+  let(:with_ecdh) { ENV.fetch('WITH_ECDH', '1') == '1' }
 
   describe '.have_recovery?' do
     it 'has the expected recovery module' do


### PR DESCRIPTION
Partially addresses #24. This makes the following changes:

* Default to download and building libsecp256k1 from GitHub zipfile.
* Add option `--with-system-library` to use system installed libsecp256k1 rather than download.