### PR TITLE
Remove Module vendor/secp256k1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/secp256k1"]
-	path = vendor/secp256k1
-	url = https://github.com/bitcoin-core/secp256k1.git

--- a/Makefile
+++ b/Makefile
@@ -2,36 +2,13 @@
 
 # Retrieve operating system name
 OS=$(shell uname -s)
-# Define the flags for libsecp256k1
-LIBSECP256K1_FLAGS=
 
 # On macOS we need to prefix to homebrew OpenSSL path before building
 ifeq ($(OS),Darwin)
 	COMPILE_PREFIX=PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
 endif
 
-# Enable recovery module
-ifeq ($(WITH_RECOVERY), 1)
-	LIBSECP256K1_FLAGS+=--enable-module-recovery
-endif
-
-# Enable EC Diffie-Hellman module
-ifeq ($(WITH_ECDH), 1)
-	LIBSECP256K1_FLAGS+= --enable-module-ecdh --enable-experimental
-endif
-
 all: test
-
-deps:
-	cd vendor/secp256k1 && \
-	./autogen.sh && \
-	./configure --disable-benchmark --disable-exhaustive-tests --enable-shared=no --disable-tests --disable-debug $(LIBSECP256K1_FLAGS) && \
-	make && \
-	sudo make install
-
-uninstall-deps:
-	cd vendor/secp256k1 && \
-	sudo make uninstall
 
 setup:
 	bundle install

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ctx.verify(sig, public_key, Digest::SHA256.digest("test message"))
 To clone the repository and its submodules you'll need to the following:
 
 ```
-git clone --recurse-submodules git@github.com:etscrivner/rbsecp256k1.git
+git clone git@github.com:etscrivner/rbsecp256k1.git
 ```
 
 ### Installing libsecp256k1


### PR DESCRIPTION
We no longer need to vendor libsecp256k1 since we now download and compile it
as part of the compilation process.