### PR TITLE
Automatically Infer Homebrew OpenSSL Path On MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,5 @@
 .PHONY: setup build test lint gem install uninstall clean docserver
 
-# Retrieve operating system name
-OS=$(shell uname -s)
-
-# On macOS we need to prefix to homebrew OpenSSL path before building
-ifeq ($(OS),Darwin)
-	COMPILE_PREFIX=PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
-endif
-
 all: test
 
 setup:

--- a/ext/rbsecp256k1/extconf.rb
+++ b/ext/rbsecp256k1/extconf.rb
@@ -2,6 +2,19 @@ require 'mini_portile2'
 require 'mkmf'
 require 'zip'
 
+# Indicates the platform on which the package is being installed
+INSTALLING_OS =
+  if RUBY_PLATFORM =~ /darwin/
+    :macos
+  elsif RUBY_PLATFORM =~ /linux/
+    :linux
+  else
+    :unknown
+  end
+
+# Fixed path to Homebrew OpenSSL pkgconfig file
+HOMEBREW_OPENSSL_PKGCONFIG = '/usr/local/opt/openssl/lib/pkgconfig'.freeze
+
 # Recipe for downloading and building libsecp256k1 as part of installation
 class Secp256k1Recipe < MiniPortile
   # Hard-coded URL for libsecp256k1 zipfile (HEAD of master as of 26-11-2018)
@@ -70,13 +83,48 @@ class Secp256k1Recipe < MiniPortile
 end
 
 # OpenSSL flags
-print("checking for OpenSSL\n")
+message("checking for OpenSSL\n")
 results = pkg_config('openssl')
+
+# Failed to find package OpenSSL
+unless results && results[1]
+  # Check if the user happens to have OpenSSL installed via Homebrew on a path
+  # we know about.
+  # rubocop:disable Style/GlobalVars
+  if INSTALLING_OS == :macos && File.exist?(HOMEBREW_OPENSSL_PKGCONFIG)
+    begin
+      require 'rubygems'
+      gem 'pkg-config', (gem_ver = '~> 1.3')
+      require 'pkg-config'
+    rescue LoadError
+      message(
+        "pkg-config could not be used to find openssl\n" \
+        "Please install either `pkg-config` or the pkg-config gem via\n" \
+        "gem install pkg-config -v #{gem_ver.inspect}\n\n"
+      )
+    else
+      message("Initial check failed. Trying homebrew openssl path...\n")
+      message("Using pkg-config gem version #{PKGConfig::VERSION}\n")
+      PKGConfig.add_path(HOMEBREW_OPENSSL_PKGCONFIG)
+
+      cflags = PKGConfig.cflags('openssl')
+      ldflags = PKGConfig.libs_only_L('openssl')
+      libs = PKGConfig.libs_only_l('openssl')
+
+      $CFLAGS += " " << cflags if cflags
+      $libs += " " << libs if libs
+      $LDFLAGS = [$LDFLAGS, ldflags].join(' ')
+
+      results = [cflags, libs, ldflags]
+    end
+  end
+  # rubocop:enable Style/GlobalVars
+end
 abort "missing openssl pkg-config information" unless results && results[1]
 
 if with_config('system-library')
   # Require that libsecp256k1 be installed using `make install` or similar.
-  print("checking for libsecp256k1\n")
+  message("checking for libsecp256k1\n")
   results = pkg_config('libsecp256k1')
   abort "missing libsecp256k1" unless results && results[1]
 else

--- a/rbsecp256k1.gemspec
+++ b/rbsecp256k1.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Dependencies required to build and run this gem
   s.add_dependency 'mini_portile2', '~> 2.4'
+  s.add_dependency 'pkg-config', '~> 1.3'
   s.add_dependency 'rubyzip', '~> 1.2'
 
   # Development dependencies


### PR DESCRIPTION
If finding the openssl package fails, then automatically attempt to look in
the Homebrew SSL install path on macOS before failing.