### PR TITLE
Add exception hierarchy

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -38,7 +38,7 @@ Instance Methods
 **Requires:** libsecp256k1 was built with the experimental ECDH module.
 
 Takes a `point` ([PublicKey](public_key.md)) and a `scalar` ([PrivateKey](private_key.md)) and returns a new
-[SharedSecret](shared_secret.md) containing the 32-byte shared secret. Raises a `RuntimeError` if
+[SharedSecret](shared_secret.md) containing the 32-byte shared secret. Raises a `Secp256k1::Error` if
 the `scalar` is invalid (zero or causes an overflow).
 
 #### generate_key_pair
@@ -49,7 +49,7 @@ secure random number generator (CSRNG) provided by OpenSSL.
 #### key_pair_from_private_key(private_key_data)
 
 Returns a new [KeyPair](key_pair.md) from the given `private_key_data`. The
-`private_key_data` is expected to be a binary string. Raises a `RuntimeError`
+`private_key_data` is expected to be a binary string. Raises a `Secp256k1::Error`
 if the private key is invalid or key derivation fails.
 
 #### recoverable_signature_from_compact(compact_signature, recovery_id)
@@ -57,7 +57,7 @@ if the private key is invalid or key derivation fails.
 **Requires:** libsecp256k1 was build with recovery module.
 
 Attempts to load a [RecoverableSignature](recoverable_signature.md) from the given `compact_signature`
-and `recovery_id`. Raises a RuntimeError if the signature data or recovery ID are invalid.
+and `recovery_id`. Raises a `Secp256k1::DeserializationError` if the signature data or recovery ID are invalid.
 
 #### sign(private_key, hash32)
 

--- a/documentation/private_key.md
+++ b/documentation/private_key.md
@@ -11,7 +11,7 @@ Class Methods
 #### from_data(private_key_data)
 
 Loads new private key from the given binary `private_key_data` string. Raises
-`ArgumentError` if the given data is invalid.
+`Secp256k1::Error` if the given data is invalid.
 
 Instance Methods
 ----------------

--- a/documentation/public_key.md
+++ b/documentation/public_key.md
@@ -13,8 +13,8 @@ Class Methods
 #### from_data(public_key_data)
 
 Parses compressed or uncompressed from binary string `public_key_data` and
-creates and returns a new public key from it. Raises a `RuntimeError` if the
-given public key data is invalid.
+creates and returns a new public key from it. Raises a `Secp256k1::DeserializationError`
+if the given public key data is invalid.
 
 Instance Methods
 ----------------

--- a/documentation/signature.md
+++ b/documentation/signature.md
@@ -12,12 +12,12 @@ Class Methods
 #### from_compact(compact_signature)
 
 Parses a signature from binary string `compact_signature`. Raises a
-`RuntimeError` ig the signature data is invalid.
+`Secp256k1::DeserializationError` if the signature data is invalid.
 
 #### from_der_encoded(der_encoded_signature)
 
 Parses a signature from binary string `der_encoded_signature`. Raises a
-`RuntimeError` ig the signature data is invalid.
+`Secp256k1::DeserializationError` if the signature data is invalid.
 
 Instance Methods
 ----------------

--- a/rbsecp256k1.gemspec
+++ b/rbsecp256k1.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.name    = 'rbsecp256k1'
   s.version = Secp256k1::VERSION
   s.summary =
-    'Compiled, native ruby extension interfaces to libsecp256k1. In rbsecp256k1 3.0.0 ' \
-    'and later libsecp256k1 is bundled with the gem.'
+    'Native extension for secp256k1 ECDSA. Wraps libsecp256k1. In ' \
+    'rbsecp256k1 3.0.0 and later libsecp256k1 is bundled with the gem.'
   s.license = 'MIT'
   s.authors = ['Eric Scrivner']
   s.homepage = 'https://github.com/etscrivner/rbsecp256k1'

--- a/spec/unit/rbsecp256k1/context_spec.rb
+++ b/spec/unit/rbsecp256k1/context_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Secp256k1::Context do
     it 'raises an error if too few bytes are given' do
       expect do
         Secp256k1::Context.new(context_randomization_bytes: '1234')
-      end.to raise_error(ArgumentError, "context_randomization_bytes must be 32 bytes in length")
+      end.to raise_error(Secp256k1::Error, "context_randomization_bytes must be 32 bytes in length")
     end
 
     it 'raises an error if too many bytes are given' do
       expect do
         Secp256k1::Context.new(context_randomization_bytes: '1' * 33)
-      end.to raise_error(ArgumentError, "context_randomization_bytes must be 32 bytes in length")
+      end.to raise_error(Secp256k1::Error, "context_randomization_bytes must be 32 bytes in length")
     end
 
     it 'allows for 32 bytes of randomness' do
@@ -65,7 +65,7 @@ RSpec.describe Secp256k1::Context do
     it 'raises an error if private key data is invalid' do
       expect do
         subject.key_pair_from_private_key('abcdefghijklmnopqrstuvwxyzabcd')
-      end.to raise_error(ArgumentError, 'private key data must be 32 bytes in length')
+      end.to raise_error(Secp256k1::Error, 'private key data must be 32 bytes in length')
     end
 
     it 'raises an error if private key data is not string' do
@@ -100,7 +100,7 @@ RSpec.describe Secp256k1::Context do
     it 'raises an error if signature is not 32 bytes' do
       expect do
         subject.sign(key_pair.private_key, text_message)
-      end.to raise_error(ArgumentError)
+      end.to raise_error(Secp256k1::Error)
     end
   end
 
@@ -133,7 +133,7 @@ RSpec.describe Secp256k1::Context do
 
       expect do
         subject.verify(signature, bad_key_pair.public_key, message)
-      end.to raise_error(ArgumentError)
+      end.to raise_error(Secp256k1::Error)
     end
   end
 
@@ -163,7 +163,7 @@ RSpec.describe Secp256k1::Context do
       it 'raises an error if hash is the wrong length' do
         expect do
           subject.sign_recoverable(subject, text_message)
-        end.to raise_error(ArgumentError)
+        end.to raise_error(Secp256k1::Error)
       end
     end
 
@@ -183,7 +183,7 @@ RSpec.describe Secp256k1::Context do
       it 'raises an error if compact signature is not the right size' do
         expect do
           subject.recoverable_signature_from_compact('test', 1)
-        end.to raise_error(ArgumentError, 'compact signature is not 64 bytes')
+        end.to raise_error(Secp256k1::Error, 'compact signature is not 64 bytes')
       end
 
       it 'raises an error if compact signature data is not string' do
@@ -198,7 +198,7 @@ RSpec.describe Secp256k1::Context do
 
         expect do
           subject.recoverable_signature_from_compact(compact, -1)
-        end.to raise_error(ArgumentError, /invalid recovery ID/)
+        end.to raise_error(Secp256k1::Error, /invalid recovery ID/)
       end
 
       it 'raises an error if recovery id is > 3' do
@@ -207,7 +207,7 @@ RSpec.describe Secp256k1::Context do
 
         expect do
           subject.recoverable_signature_from_compact(compact, 4)
-        end.to raise_error(ArgumentError, /invalid recovery ID/)
+        end.to raise_error(Secp256k1::Error, /invalid recovery ID/)
       end
     end
   end

--- a/spec/unit/rbsecp256k1/private_key_spec.rb
+++ b/spec/unit/rbsecp256k1/private_key_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Secp256k1::PrivateKey do
     it 'raises an error if private key has wrong length' do
       expect do
         Secp256k1::PrivateKey.from_data('test')
-      end.to raise_error(ArgumentError, 'private key data must be 32 bytes in length')
+      end.to raise_error(Secp256k1::Error, 'private key data must be 32 bytes in length')
     end
 
     it 'raises an error if private key data is not string' do

--- a/spec/unit/rbsecp256k1/public_key_spec.rb
+++ b/spec/unit/rbsecp256k1/public_key_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Secp256k1::PublicKey do
     it 'raises an error if public key is invalid' do
       expect do
         Secp256k1::PublicKey.from_data(Random.new.bytes(64))
-      end.to raise_error(RuntimeError, 'invalid public key data')
+      end.to raise_error(Secp256k1::DeserializationError, 'invalid public key data')
     end
 
     it 'raises an error if public key data is not string' do


### PR DESCRIPTION
Closes #41 by adding the following exception hierarchy under the Secp256k1
module:

```
Error < StandardError
├── SerializationError
├── DeserializationError
```

These exceptions are then used to replace most occurrences of `ArgumentError`
and `RuntimeError`. This will help packages using the library to isolate their
exception handling code to just those exceptions raised by the library itself.