### PR TITLE
Add valgrind Memory Leak Checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ os:
   - "linux"
   - "osx"
 
+services:
+  - "docker"
+
 # WITH_RECOVERY and WITH_ECDH are 1 by default. Test all variants where they
 # are 0.
 env:
@@ -28,6 +31,7 @@ addons:
       - libgmp-dev
       - python-dev
       - libgmp10
+      - valgrind
 
 before_install:
   - gem update --system
@@ -40,3 +44,4 @@ script:
   - make build
   - make lint
   - make test
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make memcheck ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.5
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y apt-utils build-essential
+
+RUN apt-get install -y valgrind
+RUN apt-get install -y ruby ruby-dev bundler
+RUN gem install bundler
+
+RUN mkdir /app
+
+COPY Gemfile rbsecp256k1.gemspec /app/
+COPY . /app
+
+WORKDIR /app
+RUN bundle install

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
-.PHONY: setup build test lint gem install uninstall clean docserver
+.PHONY: build clean docker docserver gem install lint memcheck setup test uninstall
 
 all: test
-
-setup:
-	bundle install
 
 build:
 	$(COMPILE_PREFIX) bundle exec rake compile
 
-test: build
-	bundle exec rspec
+clean:
+	rm -rf *~ rbsecp256k1-*.gem lib/rbsecp256k1/rbsecp256k1.so tmp .yardoc
 
-lint:
-	bundle exec rubocop
+docker:
+	docker build -t rbsecp256k1 .
+
+docserver:
+	bundle exec yard server --reload
 
 gem:
 	gem build rbsecp256k1.gemspec
@@ -20,11 +20,20 @@ gem:
 install: gem
 	gem install rbsecp256k1-*.gem
 
+lint:
+	bundle exec rubocop
+
+memcheck: build
+	valgrind --trace-children=yes --num-callers=50 --error-limit=no --partial-loads-ok=yes --undef-value-errors=no --error-exitcode=42 --gen-suppressions=all --max-stackframe=8382656 bundle exec rspec
+
+memcheck-docker: docker
+	docker run rbsecp256k1 /bin/sh -c "make memcheck"
+
+setup:
+	bundle install
+
+test: build
+	bundle exec rspec
+
 uninstall:
 	gem uninstall rbsecp256k1
-
-clean:
-	rm -rf *~ rbsecp256k1-*.gem lib/rbsecp256k1/rbsecp256k1.so tmp .yardoc
-
-docserver:
-	bundle exec yard server --reload

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ To test with both disabled run:
 make test WITH_RECOVERY=0 WITH_ECDH=0
 ```
 
+Testing for memory leaks with valgrind:
+
+```
+make memcheck
+```
+
 ### Building Gem
 
 ```


### PR DESCRIPTION
Add the ability to run Valgrind's memcheck to check for memory leaks in when
running the test suite.

Adds the following three new make targets:

* `make docker` - creates a Docker image using the new Dockerfile.
* `make memcheck` - runs valgrind memcheck against the rspec test suite.
* `make memcheck-docker` - creates Docker container and runs memcheck within it.

These new make targets are used to create and run the valgrind tests as part
of the normal test suite.