### PR TITLE
Removed require 'rbsecp256k1/rbsecp256k1' from lib/rbsecp256k1.rb

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['2.7', '3.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
@@ -26,7 +26,7 @@ jobs:
     - name: APT dependencies (Ubuntu)
       run: |
         sudo apt update
-        sudo apt install  build-essential automake pkg-config libtool libffi-dev libssl-dev libgmp-dev python-dev libgmp10 valgrind
+        sudo apt install  build-essential automake pkg-config libtool libffi-dev libssl-dev libgmp-dev python3-dev libgmp10 valgrind
       if: startsWith(matrix.os, 'Ubuntu')
     - name: Homebrew dependencies (macOS)
       run: |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install the dependencies for building libsecp256k1 and this library:
 
 ```
 sudo apt-get install build-essential automake pkg-config libtool \
-  libffi-dev libssl-dev libgmp-dev python-dev
+  libffi-dev libssl-dev libgmp-dev python3-dev
 ```
 
 **NOTE:** If you have installed libsecp256k1 but the gem cannot find it. Ensure

--- a/lib/rbsecp256k1.rb
+++ b/lib/rbsecp256k1.rb
@@ -7,4 +7,3 @@ end
 require 'rbsecp256k1/context'
 require 'rbsecp256k1/util'
 require 'rbsecp256k1/version'
-require 'rbsecp256k1/rbsecp256k1'


### PR DESCRIPTION
Fix for https://github.com/etscrivner/rbsecp256k1/issues/61 which I've tested in my previously failing app using `gem "rbsecp256k1", git: "https://github.com/schinery/rbsecp256k1"`.

Also updated the test matrix to include Ruby 3.1 and 3.2.