### PR TITLE
Fix: Workflows failing at python-dev dependency

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -26,7 +26,7 @@ jobs:
     - name: APT dependencies (Ubuntu)
       run: |
         sudo apt update
-        sudo apt install  build-essential automake pkg-config libtool libffi-dev libssl-dev libgmp-dev python-dev libgmp10 valgrind
+        sudo apt install  build-essential automake pkg-config libtool libffi-dev libssl-dev libgmp-dev python3-dev libgmp10 valgrind
       if: startsWith(matrix.os, 'Ubuntu')
     - name: Homebrew dependencies (macOS)
       run: |


### PR DESCRIPTION
Fix the currently failing workflow builds due to `python-dev` apt dependency being replaced by `python`