### PR TITLE
Upgrade To Official Release libsecp256k1 v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,10 @@ To test with recovery functionality disabled run:
 make test WITH_RECOVERY=0
 ```
 
-To test with ECDH functionality disabled run:
-
-```
-make test WITH_ECDH=0
-```
-
 To test with both disabled run:
 
 ```
-make test WITH_RECOVERY=0 WITH_ECDH=0
+make test WITH_RECOVERY=0
 ```
 
 Testing for memory leaks with valgrind:

--- a/documentation/releases/release-process.md
+++ b/documentation/releases/release-process.md
@@ -6,8 +6,7 @@ Release Process
 * Update version in `lib/rbsecp256k1/version.rb`
 * Building against libsecp256k1 without any modules works (`make clean && make test`)
 * Building against libsecp256k1 with recovery module works (`make clean &&  make test WITH_RECOVERY=0`)
-* Building against libsecp256k1 with ECDH module works (`make clean && make test WITH_ECDH=0`)
-* Building against libsecp256k1 with both modules works (`make clean && make test WITH_RECOVERY=0 WITH_ECDH=0`)
+* Building against libsecp256k1 with both modules works (`make clean && make test WITH_RECOVERY=0`)
 
 ### Cutting A Release
 

--- a/spec/unit/secp256k1_spec.rb
+++ b/spec/unit/secp256k1_spec.rb
@@ -8,11 +8,6 @@ RSpec.describe Secp256k1 do
   # uninstalled. The recovery module will be installed by default.
   let(:with_recovery) { ENV.fetch('WITH_RECOVERY', '1') == '1' }
 
-  # Pull down the WITH_ECDH environment variable. This should be '0' in
-  # environments where tests are being run with the ECDH module not installed.
-  # The ECDH module will be installed by default.
-  let(:with_ecdh) { ENV.fetch('WITH_ECDH', '1') == '1' }
-
   describe '.have_recovery?' do
     it 'has the expected recovery module' do
       expect(Secp256k1.have_recovery?).to eq(with_recovery)
@@ -21,7 +16,7 @@ RSpec.describe Secp256k1 do
 
   describe '.have_ecdh?' do
     it 'has the expected ecdh module' do
-      expect(Secp256k1.have_ecdh?).to eq(with_ecdh)
+      expect(Secp256k1.have_ecdh?).to be true
     end
   end
 end


### PR DESCRIPTION
libsecp256k1 is now undergoing an officially release process with proper
stability and versioning. Upgrade rbsecp256k1 to use the official release
version. This involved:

  * Changing the download URL in extconf.rb to the official release.

  * Updating the SHA256 hash to that of the libsecp256k1-0.2.0.zip.

  * Removing ECDH module enablement code as it is now enabled by default.

  * Checking for additional headers.

  * Changing secp256k1_context_no_precomp => secp256k1_context_static to fix
    deprecation warning.