### PR TITLE
Documentation and Code Cleanup For ECDH

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,32 +100,6 @@ To test with recovery functionality disabled run:
 make test WITH_RECOVERY=0
 ```
 
-To test with both disabled run:
-
-```
-make test WITH_RECOVERY=0
-```
-
-Testing for memory leaks with valgrind:
-
-```
-make memcheck
-```
-
-### Building Gem
-
-```
-make gem
-```
-
-### Installing Gem Locally
-
-To install the gem locally and verify builds you can run:
-
-```
-make install
-```
-
 ### Uninstall Gem Locally
 
 You can similarly uninstall the local gem by running the following:

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -35,16 +35,16 @@ Instance Methods
 
 #### ecdh(point, scalar)
 
-**Requires:** libsecp256k1 was built with the experimental ECDH module.
-
 Takes a `point` ([PublicKey](public_key.md)) and a `scalar` ([PrivateKey](private_key.md)) and returns a new
 [SharedSecret](shared_secret.md) containing the 32-byte shared secret. Raises a `Secp256k1::Error` if
 the `scalar` is invalid (zero or causes an overflow).
 
 #### generate_key_pair
 
-Generates and returns a new [KeyPair](key_pair.md) using a cryptographically
-secure random number generator (CSRNG) provided by OpenSSL.
+Generates and returns a new [KeyPair](key_pair.md) using Ruby's built-in
+`SecureRandom` cryptographically secure random number generator. This method
+simply invokes `key_pair_from_private_key` with the value from
+`SecureRandom.random_bytes`.
 
 #### key_pair_from_private_key(private_key_data)
 

--- a/documentation/shared_secret.md
+++ b/documentation/shared_secret.md
@@ -3,8 +3,6 @@
 Secp256k1::SharedSecret
 =======================
 
-**Requires:** libsecp256k1 was build with ECDH module.
-
 Secp256k1::SharedSecret represents a 32-byte shared secret computed from a
 public key (point) and private key (scalar).
 

--- a/ext/rbsecp256k1/extconf.rb
+++ b/ext/rbsecp256k1/extconf.rb
@@ -101,7 +101,7 @@ else
   have_library("gmp")
 end
 
-# Check for the basic header
+# Sanity check for the basic library
 have_header('secp256k1.h')
 
 # Check if we have the libsecp256k1 recoverable signature header.

--- a/ext/rbsecp256k1/rbsecp256k1.c
+++ b/ext/rbsecp256k1/rbsecp256k1.c
@@ -7,18 +7,28 @@
 //
 // Dependencies:
 //   * libsecp256k1
+
+// Sanity check that we have the basic header files we expect.
+#if !defined(HAVE_SECP256K1_H)
+  #error missing secp256k1.h during build
+#endif // !defined(HAVE_SECP256K1_H)
+
 #include <ruby.h>
 #include <secp256k1.h>
 
-// Include recoverable signatures functionality if available
+// Check for optional sub-modules. As a rule any secp256k1 submodule is
+// optional and so should be blocked off using these ifdefs.
 #ifdef HAVE_SECP256K1_RECOVERY_H
 #include <secp256k1_recovery.h>
 #endif // HAVE_SECP256K1_RECOVERY_H
 
-// Include EC Diffie-Hellman functionality
 #ifdef HAVE_SECP256K1_ECDH_H
 #include <secp256k1_ecdh.h>
 #endif // HAVE_SECP256K1_ECDH_H
+
+#ifdef HAVE_SECP256K1_SCHNORRSIG_H
+#include <secp256k1_schnorrsig.h>
+#endif // HAVE_SECP256K1_SCHNORRSIG_H
 
 // High-level design:
 //
@@ -29,12 +39,12 @@
 // |--  KeyPair
 // |--  PublicKey
 // |--  PrivateKey
-// |--  RecoverableSignature
-// |--  SharedSecret
+// |--  RecoverableSignature (recovery module)
+// |--  SharedSecret (ecdh module)
 // |--  Signature
 //
 // The Context class contains most of the methods that invoke libsecp256k1.
-// The KayPair, PublicKey, PrivateKey, RecoverableSignature, SharedSecret, and
+// The KeyPair, PublicKey, PrivateKey, RecoverableSignature, SharedSecret, and
 // Signature objects act as data objects and are passed to various
 // methods. Contexts are thread safe and can be used across
 // applications. Context initialization is expensive so it is recommended that


### PR DESCRIPTION
The ECDH module is now on by default so clean up any documentation and code previously referencing that it required explicit enabling.