### PR TITLE
Add Support For X-Only Public Keys

### DIFF
--- a/documentation/public_key.md
+++ b/documentation/public_key.md
@@ -27,6 +27,10 @@ Returns the binary compressed representation of this public key.
 
 Returns the binary uncompressed representation of this public key.
 
+### to_xonly
+
+Returns the `XOnlyPublicKey` equivalent of this key.
+
 #### ==(other)
 
 Return `true` if this public key matches `other`.

--- a/documentation/xonly_public_key.md
+++ b/documentation/xonly_public_key.md
@@ -1,0 +1,29 @@
+[Index](index.md)
+
+Secp256k1::XOnlyPublicKey
+=========================
+
+Secp256k1::XOnlyPublicKey represents an x-only public key version of a public key.
+
+See: [KeyPair](key_pair.md)
+
+Class Methods
+-------------
+
+#### from_data(xonly_public_key_serialized)
+
+Parses the 32-byte serialized binary `xonly_public_key_serialized` and creates
+and returns a new x-only public key from it. Raises a
+`Secp256k1::DeserializationError` if the given x-only public key data is
+invalid.
+
+Instance Methods
+----------------
+
+#### serialized
+
+Serializes the `XOnlyPublicKey` into a 32-byte binary `String`.
+
+#### ==(other)
+
+Return `true` if this x-only public key matches `other`.

--- a/spec/unit/rbsecp256k1/public_key_spec.rb
+++ b/spec/unit/rbsecp256k1/public_key_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe Secp256k1::PublicKey do
     end
   end
 
+  describe '#to_xonly' do
+    it 'returns an x-only public key' do
+      xonly = key_pair.public_key.to_xonly
+      expect(xonly).to be_a(Secp256k1::XOnlyPublicKey)
+    end
+  end
+
   describe '.from_data' do
     it 'loads compressed public key' do
       public_key = Secp256k1::PublicKey.from_data(key_pair.public_key.compressed)

--- a/spec/unit/rbsecp256k1/xonly_public_key_spec.rb
+++ b/spec/unit/rbsecp256k1/xonly_public_key_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Secp256k1::XOnlyPublicKey do
+  let(:context) { Secp256k1::Context.create }
+  let(:key_pair) { context.generate_key_pair }
+  let(:xonly_pubkey) { key_pair.public_key.to_xonly }
+
+  describe '#serialized' do
+    it 'returns a 32-byte string value' do
+      serialized = xonly_pubkey.serialized
+      expect(serialized).to be_a(String)
+      expect(serialized.length).to eq(32)
+    end
+  end
+
+  describe '.from_data' do
+    it 'produces x-only public key from serialized form' do
+      result = Secp256k1::XOnlyPublicKey.from_data(xonly_pubkey.serialized)
+      expect(result).to eq(xonly_pubkey)
+    end
+  end
+
+  describe '==' do
+    it 'is false if keys do not match' do
+      other = context.generate_key_pair.public_key.to_xonly
+      expect(other).not_to eq(xonly_pubkey)
+    end
+  end
+end


### PR DESCRIPTION
Part of the path to adding Schnorr signature support (#44).

Add a new class `XOnlyPublicKey` that represents a x-only pubkey. Include documentation for the new class. Add `PublicKey#to_xonly` to convert a `PublicKey` to an `XOnlyPublicKey`.