### PR TITLE
Add KeyPair#xonly_public_key Method

### DIFF
--- a/documentation/key_pair.md
+++ b/documentation/key_pair.md
@@ -12,6 +12,10 @@ Instance Methods
 
 Returns the [PublicKey](public_key.md) part of this key pair.
 
+#### xonly_public_key
+
+Returns the [XOnlyPublicKey](xonly_public_key.md).
+
 #### private_key
 
 Returns the [PrivateKey](private_key.md) part of this key pair.

--- a/ext/rbsecp256k1/rbsecp256k1.c
+++ b/ext/rbsecp256k1/rbsecp256k1.c
@@ -808,6 +808,32 @@ KeyPair_public_key(VALUE self)
 }
 
 /**
+ * Retrieve the x-only public key for the given key pair.
+ *
+ * @return [Secp256k1::XOnlyPublicKey] x-only public key corresponding to
+ * private key.
+ */
+static VALUE
+KeyPair_xonly_public_key(VALUE self)
+{
+  KeyPair *key_pair;
+  VALUE result;
+  XOnlyPublicKey *xonly_pubkey;
+
+  TypedData_Get_Struct(self, KeyPair, &KeyPair_DataType, key_pair);
+
+  result = XOnlyPublicKey_alloc(Secp256k1_XOnlyPublicKey_class);
+  TypedData_Get_Struct(result, XOnlyPublicKey, &XOnlyPublicKey_DataType, xonly_pubkey);
+
+  if (secp256k1_keypair_xonly_pub(secp256k1_context_static, &xonly_pubkey->pubkey, NULL, &key_pair->keypair) == 0)
+  {
+    rb_raise(Secp256k1_Error_class, "failed to derive x-only public key from keypair");
+  }
+
+  return result;
+}
+
+/**
  * Retrieve the private key for the given key pair.
  *
  * @return [Secp256k1::PrivateKey] public key corresponding to private key.
@@ -1767,6 +1793,7 @@ void Init_rbsecp256k1(void)
   rb_define_alloc_func(Secp256k1_KeyPair_class, KeyPair_alloc);
   rb_define_method(Secp256k1_KeyPair_class, "public_key", KeyPair_public_key, 0);
   rb_define_method(Secp256k1_KeyPair_class, "private_key", KeyPair_private_key, 0);
+  rb_define_method(Secp256k1_KeyPair_class, "xonly_public_key", KeyPair_xonly_public_key, 0);
   rb_define_method(Secp256k1_KeyPair_class, "==", KeyPair_equals, 1);
 
   // Secp256k1::PublicKey

--- a/spec/unit/rbsecp256k1/xonly_public_key_spec.rb
+++ b/spec/unit/rbsecp256k1/xonly_public_key_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Secp256k1::XOnlyPublicKey do
   let(:context) { Secp256k1::Context.create }
   let(:key_pair) { context.generate_key_pair }
-  let(:xonly_pubkey) { key_pair.public_key.to_xonly }
+  let(:xonly_pubkey) { key_pair.xonly_public_key }
 
   describe '#serialized' do
     it 'returns a 32-byte string value' do
@@ -24,7 +24,7 @@ RSpec.describe Secp256k1::XOnlyPublicKey do
 
   describe '==' do
     it 'is false if keys do not match' do
-      other = context.generate_key_pair.public_key.to_xonly
+      other = context.generate_key_pair.xonly_public_key
       expect(other).not_to eq(xonly_pubkey)
     end
   end


### PR DESCRIPTION
Part of #44 

Add a new convenience method, `KeyPair#xonly_public_key`, for easily retrieving the x-only public key from a `KeyPair`.