### PR TITLE
Add Schnorr Signature Support

### DIFF
--- a/documentation/context.md
+++ b/documentation/context.md
@@ -73,6 +73,10 @@ Signs the data represented by the SHA-256 hash `hash32` using `private_key` and 
 new [RecoverableSignature](recoverable_signature.md). The `private_key` is expected to be a [PrivateKey](private_key.md) and
 `data` can be either a binary string or text.
 
+#### tagged_sha256(tag, message)
+
+Computes the tagged hash as defined in [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki). Returns the 32-byte binary string tagged hash.
+
 #### verify(signature, public_key, hash32)
 
 Verifies the given `signature` ([Signature](signature.md)) was signed by

--- a/documentation/context.md
+++ b/documentation/context.md
@@ -73,6 +73,19 @@ Signs the data represented by the SHA-256 hash `hash32` using `private_key` and 
 new [RecoverableSignature](recoverable_signature.md). The `private_key` is expected to be a [PrivateKey](private_key.md) and
 `data` can be either a binary string or text.
 
+#### sign_schnorr(keypair, message)
+
+Same as `sign_schnorr_custom(keypair, message, auxrand)` but generates
+`auxrand` for you using `SecureRandom`. This should almost always be the method
+used for Schnorr signing.
+
+#### sign_schnorr_custom(keypair, message, auxrand)
+
+Sign the given 32-byte binary string `message` using the given `keypair`. It is
+recommend that `message` be generated using `tagged_sha256`. `auxrand` should
+be 32-bytes of fresh randomness, but can optionally be `nil` if generating
+randomness is expensive.
+
 #### tagged_sha256(tag, message)
 
 Computes the tagged hash as defined in [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki). Returns the 32-byte binary string tagged hash.

--- a/documentation/schnorr_signature.md
+++ b/documentation/schnorr_signature.md
@@ -1,0 +1,30 @@
+[Index](index.md)
+
+Secp256k1::SchnorrSignature
+===========================
+
+Secp256k1::SchnorrSignature represents an Schnorr signature signing a 32-byte message.
+
+Class Methods
+-------------
+
+#### from_data(schnorr_sig_data)
+
+Loads a new Schnorr signature from the given 64-byte binary
+`schnorr_sig_data`. Does not perform any validation on the loaded data.
+
+Instance Methods
+----------------
+
+#### serialized
+
+Returns the 64-byte binary `String` of the serialized Schnorr signature.
+
+#### verify(msg, xonly_pubkey)
+
+Returns `true` if the schnorr signature is a valid signing of `msg` with the
+private key for `xonly_pubkey`, `false` otherwise.
+
+#### ==(other)
+
+Returns `true` if this signature matches `other`.

--- a/documentation/secp256k1.md
+++ b/documentation/secp256k1.md
@@ -17,3 +17,8 @@ otherwise.
 
 Returns `true` if the EC Diffie-Hellman module was built with libsecp256k1,
 `false` otherwise.
+
+#### have_schnorr?
+
+Returns `true` if the Schnorr signature module was built with libsecp256k1,
+`false` otherwise.

--- a/lib/rbsecp256k1/context.rb
+++ b/lib/rbsecp256k1/context.rb
@@ -25,5 +25,12 @@ module Secp256k1
     def generate_key_pair
       key_pair_from_private_key(SecureRandom.random_bytes(32))
     end
+
+    # Create Schnorr signature generating auxrand.
+    #
+    # @return [Secp256k1::SchnorrSignature] schnorr signature
+    def sign_schnorr(keypair, message)
+      sign_schnorr_custom(keypair, message, SecureRandom.random_bytes(32))
+    end
   end
 end

--- a/spec/unit/rbsecp256k1/context_spec.rb
+++ b/spec/unit/rbsecp256k1/context_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe Secp256k1::Context do
     end
   end
 
+  describe '#tagged_sha256' do
+    it 'matches run_tagged_sha256_tests in libsecp256k1' do
+      result = subject.tagged_sha256("tag", "msg")
+
+      expect(result).to be_a(String)
+      expect(result.length).to eq(32)
+      expect(result).to eq([0x04, 0x7A, 0x5E, 0x17, 0xB5, 0x86, 0x47, 0xC1, 0x3C, 0xC6, 0xEB, 0xC0, 0xAA, 0x58, 0x3B, 0x62, 0xFB, 0x16, 0x43, 0x32, 0x68, 0x77, 0x40, 0x6C, 0xE2, 0x76, 0x55, 0x9A, 0x3B, 0xDE, 0x55, 0xB3].pack('C*'))
+    end
+  end
+
   describe '#verify' do
     it 'verifies signatures with matching public key and data' do
       signature = subject.sign(key_pair.private_key, sha256(message))

--- a/spec/unit/rbsecp256k1/schnorr_signature_spec.rb
+++ b/spec/unit/rbsecp256k1/schnorr_signature_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+if Secp256k1.have_schnorr?
+  RSpec.describe Secp256k1::SchnorrSignature do
+    let(:context) { Secp256k1::Context.create }
+    # These are from the BIP-340 test vectors
+    let(:example_sig_data1) { Secp256k1::Util.hex_to_bin("E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0") }
+    let(:example_sig_data2) { Secp256k1::Util.hex_to_bin("6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE33418906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A") }
+
+    describe '.from_data' do
+      it 'correctly loads signature from data' do
+        sig = Secp256k1::SchnorrSignature.from_data(example_sig_data1)
+
+        expect(sig.serialized).to eq(example_sig_data1)
+      end
+    end
+
+    describe '==' do
+      it 'does not match unequal values' do
+        sig1 = Secp256k1::SchnorrSignature.from_data(example_sig_data1)
+        sig2 = Secp256k1::SchnorrSignature.from_data(example_sig_data2)
+
+        expect(sig1).not_to eq(sig2)
+      end
+    end
+
+    describe 'Context#sign_schnorr' do
+      it 'generates the expected signature using BIP-340 test vector' do
+        secret_key = Secp256k1::Util.hex_to_bin('0000000000000000000000000000000000000000000000000000000000000003')
+        message = Secp256k1::Util.hex_to_bin('0000000000000000000000000000000000000000000000000000000000000000')
+        auxrand = Secp256k1::Util.hex_to_bin('0000000000000000000000000000000000000000000000000000000000000000')
+
+        expected_signature = Secp256k1::SchnorrSignature.from_data(Secp256k1::Util.hex_to_bin('E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0'))
+        expected_public_key = Secp256k1::XOnlyPublicKey.from_data(Secp256k1::Util.hex_to_bin('F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9'))
+
+        key_pair = context.key_pair_from_private_key(secret_key)
+        expect(key_pair.xonly_public_key).to eq(expected_public_key)
+
+        expect(expected_signature.verify(message, key_pair.xonly_public_key)).to be true
+
+        expect(context.sign_schnorr_custom(key_pair, message, auxrand)).to eq(expected_signature)
+
+        # Just test that we can invoke this
+        context.sign_schnorr(key_pair, message)
+      end
+    end
+  end
+end

--- a/spec/unit/secp256k1_spec.rb
+++ b/spec/unit/secp256k1_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe Secp256k1 do
       expect(Secp256k1.have_ecdh?).to be true
     end
   end
+
+  describe '.have_schnorr?' do
+    it 'has the expected schnorr module' do
+      expect(Secp256k1.have_schnorr?).to be true
+    end
+  end
 end


### PR DESCRIPTION
This completes the initial implementation of #44 

Add a new class called `SchnorrSignature` and new methods `Context#sign_schnorr` and `Context#sign_schnorr_custom` from producing these signatures. Add tests and update documentation.